### PR TITLE
Add a dockerimage.yml github action to build docker image and push to registry

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,24 @@
+name: Publish Docker image to GitHub Package Registry
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest 
+    steps:
+
+    - name: Copy Repo Files
+      uses: actions/checkout@master
+
+    - name: Publish Docker Image to GPR
+      uses: machine-learning-apps/gpr-docker-publish@master
+      id: docker
+      with:
+        USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        IMAGE_NAME: 'pymalta-ai'
+        DOCKERFILE_PATH: 'argo/gpu.Dockerfile'
+        BUILD_CONTEXT: 'argo/'


### PR DESCRIPTION
While no GPR is available, consider using publishing to hub.docker.com via

```
- name: Publish Docker Action
  uses: jerray/publish-docker-action@v1.0.2
```